### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ dinglehopper is an OCR evaluation tool and reads [ALTO](https://github.com/altox
 Goals
 -----
 * Useful
-  * As an UI tool
+  * As a UI tool
   * For an automated evaluation
   * As a library
 * Unicode support


### PR DESCRIPTION
Since *u* is pronounced `/ju/` in this case, the *n* is not added to prevent a hiatus here. Cf. https://en.wiktionary.org/wiki/an#Usage_notes.