### PR TITLE
Add travis pip caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial  # required for Python >= 3.7
 language: python
+cache: pip
 python:
   - "3.5"
   - "3.6"


### PR DESCRIPTION
The main reason for the long build time on Travis is the compilation of dependencies for Python 3.5 and Python 3.9.

By using pip caching we reduce the runtime for subsequent builds per branch by about 40 minutes.

We could speed this up further by splitting unit and integration tests and/or using anaconda but IMHO this is not yet necessary.