### PR TITLE
1 more update for core's getLogger context

### DIFF
--- a/qurator/dinglehopper/extracted_text.py
+++ b/qurator/dinglehopper/extracted_text.py
@@ -10,9 +10,6 @@ import numpy as np
 from lxml import etree as ET
 from ocrd_utils import getLogger
 
-LOG = getLogger('processor.OcrdDinglehopperEvaluate')
-
-
 class Normalization(enum.Enum):
     NFC = 1
     NFC_MUFI = 2  # TODO
@@ -246,6 +243,7 @@ def get_textequiv_unicode(text_segment, nsmap) -> str:
 
 def get_first_textequiv(textequivs, segment_id):
     """Get the first TextEquiv based on index or conf order if index is not present."""
+    LOG = getLogger('processor.OcrdDinglehopperEvaluate')
     if len(textequivs) == 1:
         return textequivs[0]
 


### PR DESCRIPTION
This avoids:
```
CRITICAL root - getLogger was called before initLogging. Source of the call:
CRITICAL root -   File "qurator/dinglehopper/extracted_text.py", line 13, in <module>
CRITICAL root -     LOG = getLogger('processor.OcrdDinglehopperEvaluate')
CRITICAL root - initLogging was called multiple times. Source of latest call:
CRITICAL root -   File "ocrd/decorators/__init__.py", line 40, in ocrd_cli_wrap_processor
CRITICAL root -     initLogging()
```
