### PR TITLE
add version to ocrd-tool.json (and setup.py)

### DIFF
--- a/qurator/dinglehopper/ocrd-tool.json
+++ b/qurator/dinglehopper/ocrd-tool.json
@@ -1,5 +1,6 @@
 {
   "git_url": "https://github.com/qurator-spk/dinglehopper",
+  "version": "0.0.1",
   "tools": {
     "ocrd-dinglehopper": {
       "executable": "ocrd-dinglehopper",

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,12 @@ with open("requirements.txt") as fp:
 with open('requirements-dev.txt') as fp:
     tests_require = fp.read()
 
+with open('ocrd-tool.json', 'r', encoding='utf-8') as f:
+    version = load(f)['version']
+
 setup(
     name="dinglehopper",
+    version=version,
     author="Mike Gerber, The QURATOR SPK Team",
     author_email="mike.gerber@sbb.spk-berlin.de, qurator@sbb.spk-berlin.de",
     description="The OCR evaluation tool",


### PR DESCRIPTION
The package should have a version, I set it to `0.0.1` for now but how you version is up to you of course. Besides the obvious need for versioning when releasing to PyPI and/or GitHub, we add the processor call, version and parameters as a `mets:agent` to the `mets.xml` to help debug/reconstruct the processing. Currently this will show `dinglehopper vNone`.

The pattern we use for this is to only ever change the version number in `ocrd-tool.json` and read it from there in the `setup.py`. That way you only need to change it once when releasing.