### PR TITLE
⬆ Update multimethod dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ colorama
 MarkupSafe
 ocrd >= 2.20.1
 attrs
-multimethod == 1.3  # latest version to officially support Python 3.5
+multimethod >= 1.3
 tqdm
 rapidfuzz >= 2.4.2
 six  # XXX workaround OCR-D/core#730


### PR DESCRIPTION
We had some issues while reviewing/rebasing #72. We don't support Python 3.5 anymore, so lifting the hard pin on multimethod 1.3.

Closes #88.