### PR TITLE
Fix a tiny typo in Levenshtein notebook

### DIFF
--- a/src/dinglehopper/notebooks/Levenshtein.ipynb
+++ b/src/dinglehopper/notebooks/Levenshtein.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "dinglehopper uses to have its own (very inefficient) Levenshtein edit distance implementation, but now uses RapidFuzz."
+    "dinglehopper used to have its own (very inefficient) Levenshtein edit distance implementation, but now uses RapidFuzz."
    ]
   },
   {


### PR DESCRIPTION
To fix a tiny typo in Levenshtein notebook.


Also I coudn't find the following link in Levenshtein.ipynb:
https://github.com/qurator-spk/dinglehopper/blob/f077ce2e1b34c9d7cbf0b5bad6d05d2593d0b577/src/dinglehopper/notebooks/Levenshtein.ipynb#L388