### PR TITLE
Add Dockerfile and Makefile to create ocr-d dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG DOCKER_BASE_IMAGE
+FROM $DOCKER_BASE_IMAGE
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL \
+    maintainer="https://ocr-d.de/kontakt" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/qurator-spk/dinglehopper" \
+    org.label-schema.build-date=$BUILD_DATE
+
+WORKDIR /build/dinglehopper
+COPY pyproject.toml .
+COPY src/dinglehopper/ocrd-tool.json .
+COPY src ./src
+COPY requirements.txt .
+COPY README.md .
+COPY Makefile .
+RUN make install
+RUN rm -rf /build/dinglehopper
+
+WORKDIR /data
+VOLUME ["/data"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PYTHON = python3
+PIP = pip3
+PYTHONIOENCODING=utf8
+
+DOCKER_BASE_IMAGE = docker.io/ocrd/core:v2.69.0
+DOCKER_TAG = ocrd/dinglehopper
+
+help:
+	@echo
+	@echo "  Targets"
+	@echo
+	@echo "    install Install full Python package via pip"
+	@echo "    docker  Build the ocrd/dinglehopper docker image"
+
+# Install Python package via pip
+install:
+	$(PIP) install .
+
+docker:
+	docker build \
+	--build-arg DOCKER_BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+	--build-arg VCS_REF=$$(git rev-parse --short HEAD) \
+	--build-arg BUILD_DATE=$$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	-t $(DOCKER_TAG) .
+
+.PHONY: help install docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ optional-dependencies.dev = {file = ["requirements-dev.txt"]}
 where = ["src"]
 
 [tool.setuptools.package-data]
-dinglehopper = ["templates/*"]
+dinglehopper = ["templates/*", "*.json"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR adds a Dockerfile and Makefile to create a dockerimage for this processor. Ideally all OCR-D processors offer the same way to create an image for them, which is currently missing in this repo.
I am not sure though if this is desired here as well, because it seems to me dinglehopper has slightly other layout as a "normal" ocr-d processor has. Dinglehopper seems also to be supposed to be used detached from ocr-d. That's why I created a draft PR at first.