### PR TITLE
✔  GitHub Actions: Make reporting results clearer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: 'Test'
 
 on:
 

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -1,4 +1,4 @@
-name: 'Test Report'
+name: 'Test - Report results'
 on:
   workflow_run:
     workflows: ['test']
@@ -15,6 +15,6 @@ jobs:
       - uses: dorny/test-reporter@v1
         with:
           artifact: /test-results-(.*)/
-          name: 'Tests Results - $1'
+          name: 'test - Results ($1)'
           path: '*junit.xml'
           reporter: java-junit


### PR DESCRIPTION
In the "Actions" tab on GitHub, the workflow run that would post test results to the _original_ workflow run is named "Test Report". This would lead me to click on it to see the results, just to be disappointed.

This aims to make the naming of the GitHub workflows/jobs clearer.